### PR TITLE
Still improved .getFormattedString([format])

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Returns the current value of the countdown as a formatted string. The method all
 
 The default format is ```%D days %H hours %M minutes %S seconds``` where ```%D``` is replaced with the current **days**, ```%H``` is replaced with the **hours**, ```%M``` is replaced with the **minutes** and ```%S``` is replaced with the **seconds**.
 
-If ```showZero``` is  ```true```, all single digit numbers will be prepend with an 0.
+If single digit numbers require padding (prepending 0), specify it with `%DD, %HH, %MM or %SS`.
+
+There may be cases where you prefer not to display a number when it is 0. To do so, just enclose it within `<!` and `>` and it is done. Moreover, whatever you enclose within `<!` and `>` will be removed from the output string. eg. `<!%HH hours >%MM minutes %SS seconds` will result in say `05 minutes 20 seconds` and not `00 hours 05 minutes 20 seconds` when hours is 0. 
 
 
 ## License

--- a/ReactiveCountdown.js
+++ b/ReactiveCountdown.js
@@ -108,7 +108,7 @@ ReactiveCountdown = (function () {
     ReactiveCountdown.prototype.getFormattedString = function(format){
         
         var format = (typeof format == 'string' || format instanceof String) ? format : '<!%DD days >%HH hours %MM minutes %SS seconds',
-            current = this.getFormattedObj();
+            current = this.getFormattedObject();
         
         var parts = [['S', 'seconds'], ['M', 'minutes'], ['H', 'hours'], ['D', 'days']];
         for(var i = 0; i < parts.length ; i++) {
@@ -125,7 +125,7 @@ ReactiveCountdown = (function () {
                             //To pad single digit parts with a preceding zero, The user has to specify %XX instead of %X
 
                             .replace(new RegExp("(.*)%" + part[0] + "(.*)", "g"), "$1" + v + "$2");
-                            //Least priority to %X not enclosed within <! >
+                            //finally replace %X not enclosed within <! >
             
         }
 

--- a/ReactiveCountdown.js
+++ b/ReactiveCountdown.js
@@ -1,125 +1,38 @@
-/**
- * flyandi:reactivecountdown 
- * A simple reactive countdown timer library
- * @version: v0.0.1
- * @author: Andy Schwarz
- *
- * Created by Andy Schwarz. Please report any bug at http://github.com/flyandi/meteor-reactive-countdown
- *
- * Copyright (c) 2015 Andy Schwarz http://github.com/flyandi
- *
- * The MIT License (http://www.opensource.org/licenses/mit-license.php)
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use,
- * copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following
- * conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
- * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
- * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
+ReactiveCountdown.prototype.getformattedString = function(format, showZero){
 
-ReactiveCountdown = (function () {
+    var format = format instanceof String ? format : '%D days %H hours %M minutes %S seconds',
+        current = this.getFormattedObject();
 
-    // Constructor
-    function ReactiveCountdown(countdown, settings) {
-    	this._settings = settings || {};
-    	this._dependency = new Tracker.Dependency;
-    	this._countdown = countdown;
-    	this._interval = this._settings.interval || 1000; 
-    	this._steps = this._settings.steps || 1;
-    	this._id = false;
-    };
-
-    ReactiveCountdown.prototype.start = function(completed, tick){
-
-    	if(completed) this._settings.completed = completed;
-    	if(tick) this._settings.tick = tick;
-
-    	this._current = this._countdown;
-
-    	this._id = Meteor.setInterval(function(){
-
-    		this._current = this._current - this._steps;
-
-    		if(typeof(this._settings.tick) == "function") {
-    			this._settings.tick();
-    		}
-
-            this._dependency.changed();
-
-    		if(this._current <= 0) {
-
-    			this.stop();
-
-    			if(typeof(this._settings.completed) == "function") {
-    				this._settings.completed();
-    			}
-    		}
-
-        }.bind(this), this._interval);
-    };
-
-    ReactiveCountdown.prototype.stop = function(){
-        Meteor.clearInterval(this._id);
-        this._id = false;
-    };
-
-    ReactiveCountdown.prototype.add = function(unit) {
-    	this._current = this._current + (unit || 0);
-    };
-
-    ReactiveCountdown.prototype.remove = function(unit) {
-    	this._current = this._current - (unit || 0);
-    };
-
-    ReactiveCountdown.prototype.get = function() {
-
-    	this._dependency.depend();
-
-    	return this._current;
-    };
-
-    ReactiveCountdown.prototype.getFormattedObject = function(seconds){
-
-        var ms = (seconds | this.__current) * 1000;
-
-        return {
-            seconds: Math.floor((ms % 6e4) / 1e3),
-            minutes: Math.floor((ms % 3.6e6) / 6e4),
-            hours:  (ms % 8.64e7)/ 3.6e6 | 0,
-            days: ms / 8.64e7 | 0
+    if(typeof showZero == undefined){
+        showZero = false;
+    }
+    if(this._steps == 1 && (this._interval == 1000 || this._interval == 60*1000 || this._interval == 60*60*1000 || this._interval == 24*60*60*1000)){
+        if(formattedObj){
+            format = format.replace(/(<([^>]*)__D([^>]*)>)/, (formattedObj.days || showZero) ? "$2" + formattedObj.days + "$3" : "");
+            format = format.replace(/(<([^>]*)__H([^>]*)>)/, (formattedObj.hours || showZero) ? "$2" + formattedObj.hours + "$3" : "");
+            format = format.replace(/(<([^>]*)__M([^>]*)>)/, (formattedObj.minutes || showZero)? "$2" + formattedObj.minutes + "$3" : "");
+            format = format.replace(/(<([^>]*)__S([^>]*)>)/, (formattedObj.seconds || showZero)? "$2" + formattedObj.seconds + "$3" : "");
+            return format;
         }
-    };
+    }
+};
 
-    ReactiveCountdown.prototype.getFormattedString = function(format, showZero){
 
-        var format = format instanceof String ? format : '%D days %H hours %M minutes %S seconds',
+    ReactiveCountdown.prototype.getFormattedString = function(){
+        
+        var format = (typeof format == 'string' || format instanceof String) ? format : '<%DD days ><%HH hours ><%MM minutes ><%SS seconds>',
             current = this.getFormattedObject();
-
-        [['S', 'seconds'], ['M', 'minutes'], ['H', 'hours'], ['D', 'days']].forEach(function(part) {
+        
+        for(var part in [['S', 'seconds'], ['M', 'minutes'], ['H', 'hours'], ['D', 'days']]) {
 
             var v =  current[part[1]] | 0;
 
-            format = format.replace(new RegExp("%" + part[0], "g"), (showZero && (v >= 0) && (v < 10) ? '0' : '') + v);
 
-        });
+            format = format.replace(new RegExp("<<([^>]*)(%" + part[0] + part[0] + "?)([^>]*)>>", "g"), v ? "<$1$2$3>" : "" )
+                            .replace(new RegExp("<([^>]*)%" + part[0] + part[0] + "([^>]*)>", "g"), "$1" + ((v >= 0) && (v < 10) ? '0' : '') + v + "$2")
+                            .replace(new RegExp("<([^>]*)%" + part[0] + "([^>]*)>", "g"), "$1" + v + "$2");
+
+        };
 
         return format;
     };
-
-    return ReactiveCountdown;
-})();

--- a/ReactiveCountdown.js
+++ b/ReactiveCountdown.js
@@ -1,22 +1,109 @@
-ReactiveCountdown.prototype.getformattedString = function(format, showZero){
+/**
+ * flyandi:reactivecountdown 
+ * A simple reactive countdown timer library
+ * @version: v0.0.1
+ * @author: Andy Schwarz
+ *
+ * Created by Andy Schwarz. Please report any bug at http://github.com/flyandi/meteor-reactive-countdown
+ *
+ * Copyright (c) 2015 Andy Schwarz http://github.com/flyandi
+ *
+ * The MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
-    var format = format instanceof String ? format : '%D days %H hours %M minutes %S seconds',
-        current = this.getFormattedObject();
+ReactiveCountdown = (function () {
 
-    if(typeof showZero == undefined){
-        showZero = false;
-    }
-    if(this._steps == 1 && (this._interval == 1000 || this._interval == 60*1000 || this._interval == 60*60*1000 || this._interval == 24*60*60*1000)){
-        if(formattedObj){
-            format = format.replace(/(<([^>]*)__D([^>]*)>)/, (formattedObj.days || showZero) ? "$2" + formattedObj.days + "$3" : "");
-            format = format.replace(/(<([^>]*)__H([^>]*)>)/, (formattedObj.hours || showZero) ? "$2" + formattedObj.hours + "$3" : "");
-            format = format.replace(/(<([^>]*)__M([^>]*)>)/, (formattedObj.minutes || showZero)? "$2" + formattedObj.minutes + "$3" : "");
-            format = format.replace(/(<([^>]*)__S([^>]*)>)/, (formattedObj.seconds || showZero)? "$2" + formattedObj.seconds + "$3" : "");
-            return format;
+    // Constructor
+    function ReactiveCountdown(countdown, settings) {
+        this._settings = settings || {};
+        this._dependency = new Tracker.Dependency;
+        this._countdown = countdown;
+        this._interval = this._settings.interval || 1000; 
+        this._steps = this._settings.steps || 1;
+        this._id = false;
+    };
+
+    ReactiveCountdown.prototype.start = function(completed, tick){
+
+        if(completed) this._settings.completed = completed;
+        if(tick) this._settings.tick = tick;
+
+        this._current = this._countdown;
+
+        this._id = Meteor.setInterval(function(){
+
+            this._current = this._current - this._steps;
+
+            if(typeof(this._settings.tick) == "function") {
+                this._settings.tick();
+            }
+
+            this._dependency.changed();
+
+            if(this._current <= 0) {
+
+                this.stop();
+
+                if(typeof(this._settings.completed) == "function") {
+                    this._settings.completed();
+                }
+            }
+
+        }.bind(this), this._interval);
+    };
+
+    ReactiveCountdown.prototype.stop = function(){
+        Meteor.clearInterval(this._id);
+        this._id = false;
+    };
+
+    ReactiveCountdown.prototype.add = function(unit) {
+        this._current = this._current + (unit || 0);
+    };
+
+    ReactiveCountdown.prototype.remove = function(unit) {
+        this._current = this._current - (unit || 0);
+    };
+
+    ReactiveCountdown.prototype.get = function() {
+
+        this._dependency.depend();
+
+        return this._current;
+    };
+
+    ReactiveCountdown.prototype.getFormattedObject = function(seconds){
+
+        var ms = (seconds | this.__current) * 1000;
+
+        return {
+            seconds: Math.floor((ms % 6e4) / 1e3),
+            minutes: Math.floor((ms % 3.6e6) / 6e4),
+            hours:  (ms % 8.64e7)/ 3.6e6 | 0,
+            days: ms / 8.64e7 | 0
         }
-    }
-};
-
+    };
 
     ReactiveCountdown.prototype.getFormattedString = function(){
         
@@ -36,3 +123,6 @@ ReactiveCountdown.prototype.getformattedString = function(format, showZero){
 
         return format;
     };
+
+    return ReactiveCountdown;
+})();


### PR DESCRIPTION
It now gives more control to the user. 

**Downside:** Three RegExp replaces per part and four parts. Which is `3 x 4 = 12` RegExp executions every second.  May compromise performance. I appreciate if you can improve on this

**Format specification:**
- If any %X or %XX is 0, anything within the surrounding `<!` and `>` to be "" (removed). This is required if a user doesn't want to display a part that is equal to 0
  
  eg. in format "<! %HH hours > ....", if the user doesn't want to display hours when (hours == 0), its of no use displaying the string next to it " hours"
  
  To do so, all he has to do is enclose a part within <! and > and it will be removed from formatted string if the part is 0.
- To pad single digit parts with a preceding zero, The user has to specify %XX instead of %X

---

Sorry for the extra stale commits. I was working at midnight.
